### PR TITLE
Remove unauthorized from NetworkError

### DIFF
--- a/Net/Sources/NetworkClient.swift
+++ b/Net/Sources/NetworkClient.swift
@@ -88,17 +88,9 @@ public class NetworkClient: NetworkClientProtocol {
   ///
   /// - Parameter request: `URLRequest` to execute.
   /// - Returns: `Observable` with a fetched `Response`. All errors are mapped into `NetworkError.unknown`.
-  /// If status is 401 emits `NetworkError.unathorized`.
   private func executeRequest(_ request: URLRequest) -> Observable<NetworkResponse> {
     return session.fire(request: request)
       .catchError { error in Observable.error(NetworkError.unknown(message: "\(error)")) }
-      .map { (response, data) throws -> (HTTPURLResponse, Data) in
-        if response.statusCode == 401 {
-          throw NetworkError.unathorized
-        }
-
-        return (response, data)
-      }
       .map { response, data in NetworkResponse(statusCode: response.statusCode, data: data) }
   }
 

--- a/Net/Sources/NetworkError.swift
+++ b/Net/Sources/NetworkError.swift
@@ -11,7 +11,6 @@ import Foundation
 public enum NetworkError: Error, Equatable {
   case serializationError(message: String)
   case apiError(code: Int, message: String)
-  case unathorized
   case unknown(message: String)
 }
 
@@ -22,8 +21,6 @@ extension NetworkError: CustomStringConvertible {
       return "Serialization: \(message)"
     case let .apiError(_, message):
       return "\(message)"
-    case .unathorized:
-      return "Unathorized"
     case let .unknown(message):
       return "Unknown: \(message)"
     }

--- a/NetTests/CompositePluginTests.swift
+++ b/NetTests/CompositePluginTests.swift
@@ -41,7 +41,7 @@ class CompositePluginTests: XCTestCase {
     let plugin1 = MockPlugin()
     let plugin2 = MockPlugin()
     let composite = CompositePlugin(plugins: [plugin1, plugin2])
-    let networkError = NetworkError.unathorized
+    let networkError = NetworkError.unknown(message: "Test Error Message")
     let scheduler = TestScheduler(initialClock: 0)
 
     let result = scheduler.start { composite.tryCatchError(networkError).map { _ in true } }
@@ -56,7 +56,7 @@ class CompositePluginTests: XCTestCase {
     plugin1.tryCatchError_ReturnValue = Observable.just(Void())
     let plugin2 = MockPlugin()
     let composite = CompositePlugin(plugins: [plugin1, plugin2])
-    let networkError = NetworkError.unathorized
+    let networkError = NetworkError.unknown(message: "Test Error Message")
     let scheduler = TestScheduler(initialClock: 0)
 
     let result = scheduler.start { composite.tryCatchError(networkError).map { _ in true } }

--- a/NetTests/NetworkClientTests.swift
+++ b/NetTests/NetworkClientTests.swift
@@ -93,18 +93,6 @@ class NetworkClientTests: XCTestCase {
     XCTAssertEqual(result.events, [next(200, expectedResponse), completed(200)])
   }
 
-  func test_On401Code_ThrowsUnathorizedError() {
-    let mockSession = NetSessionMock()
-    let response = HTTPURLResponse(url: URL(string: "https://apple.com/hello")!, statusCode: 401, httpVersion: nil, headerFields: nil)!
-    mockSession.fireRequest_ReturnValue = Observable.just((response, Data()))
-
-    initSUT(session: mockSession)
-
-    let result = scheduler.start { self.sut.request(self.sampleTarget) }
-
-    XCTAssertEqual(result.events, [error(200, NetworkError.unathorized)])
-  }
-
   func test_OnError_UsesErrorParser() {
     var errorParserWasUsed = false
     let errorParser: NetworkClient.ErrorParser = { _, _ throws -> NetworkError in


### PR DESCRIPTION
I suggest to remove `unauthorized` from `NetworkError` because it's a part of `apiError`. In some cases, you need be able to handle 401 error through `errorParser`.
For example: 
if I understand right a big part of APIs throw 401 status code when credentials are not valid on Sign In and in the result you should be able to know what was wrong. Sorry if I misunderstand something 😸